### PR TITLE
correção da grafia Assitente para Assistente

### DIFF
--- a/_mini_bios/mini_bio_ricardo_rosal.md
+++ b/_mini_bios/mini_bio_ricardo_rosal.md
@@ -1,7 +1,7 @@
 ---
 layout: mini_bio
 title:  "Ricardo Rosal"
-excerpt: "Pesquisador Assitente"
+excerpt: "Pesquisador Assistente"
 tag:
 - pesquisador_assistente
 comments: False


### PR DESCRIPTION
somente correção ortográfica da palavra assistente.